### PR TITLE
Added methods to allow Device to be accessed through ODDRService

### DIFF
--- a/src/org/openddr/simpleapi/oddr/ODDRService.java
+++ b/src/org/openddr/simpleapi/oddr/ODDRService.java
@@ -557,6 +557,10 @@ public class ODDRService implements Service {
         return ODDR_DATA_VERSION;
     }
 
+    public DeviceIdentificator getDeviceIdentificator() {
+        return deviceIdentificator;
+    }
+
     public PropertyRef[] listPropertyRefs() {
         List<PropertyRef> propertyRefsList = new ArrayList<PropertyRef>();
         Map<String, Vocabulary> vocabularies = vocabularyHolder.getVocabularies();

--- a/src/org/openddr/simpleapi/oddr/identificator/DeviceIdentificator.java
+++ b/src/org/openddr/simpleapi/oddr/identificator/DeviceIdentificator.java
@@ -42,6 +42,10 @@ public class DeviceIdentificator implements Identificator {
         this.devices = devices;
     }
 
+    public Device getById(String id) {
+        return devices.get(id);
+    }
+
     public Device get(String userAgent, int confidenceTreshold) {
         return get(UserAgentFactory.newUserAgent(userAgent), confidenceTreshold);
     }


### PR DESCRIPTION
I wanted to use the Device object directly in my application without going through the W3C API. I had to add a couple of methods to ODDRService to do so.

It would be great if this could be pulled back in so I don't have to maintain a fork.
